### PR TITLE
Added descriptions to outputs in action.yml now that they are required

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,16 +2,27 @@ name: 'Git Version'
 description: 'Output a deterministic semantic version'
 outputs:
   git_author:
+    description: 'The author of the last commit'
   git_author_email:
+    description: 'The author email of the last commit'
   git_branch:
+    description: 'The branch of the last commit'
   git_branch_clean:
+    description: 'The a semver sanitized version of the branch name'
   git_commit:
+    description: 'The commit hash of the last commit'
   git_commit_short:
+    description: 'The commit short hash of the last commit'
   git_commit_timestamp:
+    description: 'The timestamp of the last commit'
   git_commit_epoch:
+    description: 'The timestamp in epoch time of the last commit'
   git_commit_message:
-  git_ag:
+    description: 'The message of the last commit'
+  git_tag:
+    description: 'The git tag of the last commit'
   git_tag_long:
+    description: 'The long git tag of the last commit'
   git_version:
     description: 'The version based on the git metadata'
 runs:


### PR DESCRIPTION
This morning, builds using this action started failing with this message:

<img width="657" alt="Screen Shot 2020-08-04 at 9 55 05 AM" src="https://user-images.githubusercontent.com/3671561/89302351-b87e0280-d638-11ea-93b3-09b8f12a6372.png">

Looking in the [Github Action documentation](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs), the `outputs.<id>.description` is required which appears to be a change to that spec. This change adds a description for each output in the action.

### Testing

Tested this by reviewing the [unit test action](https://github.com/WPMedia/git-version-action/runs/945090522?check_suite_focus=true) for this commit